### PR TITLE
US398512: Updated to install nodejs16

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# openSUSE and NodeJS10 image
+# openSUSE and NodeJS16 image
 
-This project builds an openSUSE-based image which includes NodeJS version 10 and is based off the [OpenSUSE Base Image](https://github.com/CAFapi/opensuse-base-image). It can be used as a base image by projects which require NodeJS10.
+This project builds an openSUSE-based image which includes NodeJS version 16 and is based off the [OpenSUSE Base Image](https://github.com/CAFapi/opensuse-base-image). It can be used as a base image by projects which require NodeJS16.
 
 ### Tini
 [Tini](https://github.com/krallin/tini) is pre-installed in the container.  If the image entrypoint is not overwritten then it will be automatically used.

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2018-2022 Micro Focus or one of its affiliates.
+    Copyright 2022 Micro Focus or one of its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -22,15 +22,15 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.github.cafapi</groupId>
-    <artifactId>opensuse-nodejs10-image</artifactId>
+    <artifactId>opensuse-nodejs16-image</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
-    <name>openSUSE NodeJS10 image</name>
-    <description>An openSUSE-based image which includes NodeJS version 10.</description>
-    <url>https://github.com/CAFapi/opensuse-nodejs10-image</url>
+    <name>openSUSE NodeJS16 image</name>
+    <description>An openSUSE-based image which includes NodeJS version 16.</description>
+    <url>https://github.com/CAFapi/opensuse-nodejs16-image</url>
 
-    <inceptionYear>2018</inceptionYear>
+    <inceptionYear>2022</inceptionYear>
 
     <parent>
         <groupId>com.github.cafapi</groupId>
@@ -60,6 +60,7 @@
 
     <properties>
         <copyrightYear>2022</copyrightYear>
+        <copyrightNotice>Copyright ${copyrightYear} Micro Focus or one of its affiliates.</copyrightNotice>
         <maven.install.skip>true</maven.install.skip>
         <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         <dockerHubOrganization>cafapi</dockerHubOrganization>
@@ -94,7 +95,7 @@
                     <autoPull>always</autoPull>
                     <images>
                         <image>
-                            <name>${dockerCafImagePrefix}opensuse-nodejs10${dockerProjectVersion}</name>
+                            <name>${dockerCafImagePrefix}opensuse-nodejs16${dockerProjectVersion}</name>
                             <build>
                                 <dockerFileDir>.</dockerFileDir>
                                 <args>
@@ -113,9 +114,9 @@
     </build>
 
     <scm>
-        <connection>scm:git:https://github.com/CAFapi/opensuse-nodejs10-image.git</connection>
-        <developerConnection>scm:git:https://github.com/CAFapi/opensuse-nodejs10-image.git</developerConnection>
-        <url>https://github.com/CAFapi/opensuse-nodejs10-image</url>
+        <connection>scm:git:https://github.com/CAFapi/opensuse-nodejs16-image.git</connection>
+        <developerConnection>scm:git:https://github.com/CAFapi/opensuse-nodejs16-image.git</developerConnection>
+        <url>https://github.com/CAFapi/opensuse-nodejs16-image</url>
     </scm>
 
 </project>

--- a/release-notes-1.0.0.md
+++ b/release-notes-1.0.0.md
@@ -1,11 +1,10 @@
+!not-ready-for-release!
+
 #### Version Number
 ${version-number}
 
 #### New Features
-- None
-
-#### Patch Fixes Included
-- This release includes OS package updates only.
+- Initial Release
 
 #### Known Issues
 - None

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 Micro Focus or one of its affiliates.
+# Copyright 2022 Micro Focus or one of its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,5 +22,5 @@ FROM ${DOCKER_HUB_PUBLIC}/cafapi/opensuse-base:2
 # Update the OS packages and install NodeJS
 RUN zypper -n refresh && \
     zypper -n update && \
-    zypper -n install nodejs10 npm && \
+    zypper -n install nodejs16 npm && \
     zypper -n clean --all


### PR DESCRIPTION
There was no official package for this listed on the openSUSE software page [here](https://software.opensuse.org/package/nodejs16) but it seems to install fine so must be available.